### PR TITLE
Handle issues with package Assimp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 
 ## Version 0.9.104.0
-###### `CMake`
+##### `CMake`
  - Devel branch will now have +100 on the patch number to differentiate from master branch.
-
+ - Use CONFIG mode for Assimp, fix inclusion of headers and linking to Assimp.
+##### `Dependencies`
+ - Minimum required version of Assimp is now `3.3.0`.
 
 ## Version 0.9.4.0
 ##### `Bugfix`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ install_basic_package_files(${PROJECT_NAME}
                             NO_SET_AND_CHECK_MACRO
                             VARS_PREFIX ${PROJECT_NAME}
                             NO_CHECK_REQUIRED_COMPONENTS_MACRO
-                            DEPENDENCIES assimp "glew CONFIG" glfw3 OpenCV)
+                            DEPENDENCIES "assimp CONFIG" "glew CONFIG" glfw3 OpenCV)
 
 # Add the uninstall target
 include(AddUninstallTarget)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In particular, this library provides function to superimpose 3D mesh model on to
 # 🎛 Dependencies
 SuperimposeMesh library depends on
 - [GLFW](http://www.glfw.org) - `version >= 3.1`
-- [Open Asset Import Library, ASSIMP](http://assimp.org) - `version >= 3.0`
+- [Open Asset Import Library, ASSIMP](http://assimp.org) - `version >= 3.3.0`
 - [OpenGL Extension Wrangler, GLEW](http://glew.sourceforge.net) - `version >= 2.0`
 - [OpenCV](http://opencv.org) - `version >= 3.0`
 - [OpenGL Mathematics, GLM](http://glm.g-truc.net) - `version >= 0.9`

--- a/src/SuperimposeMesh/CMakeLists.txt
+++ b/src/SuperimposeMesh/CMakeLists.txt
@@ -18,7 +18,7 @@ set(${LIBRARY_TARGET_NAME}_HDR
         include/SuperimposeMesh/Superimpose.h)
 
 # Depndencies
-find_package(assimp REQUIRED)
+find_package(assimp REQUIRED CONFIG)
 find_package(glew   REQUIRED CONFIG)
 find_package(glfw3  REQUIRED)
 find_package(glm    REQUIRED)

--- a/src/SuperimposeMesh/CMakeLists.txt
+++ b/src/SuperimposeMesh/CMakeLists.txt
@@ -33,7 +33,7 @@ target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CM
                                                          ${ASSIMP_INCLUDE_DIRS}
                                                          ${GLM_INCLUDE_DIRS})
 
-target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC  -L${ASSIMP_LIBRARY_DIRS} ${ASSIMP_LIBRARIES}
+target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC  ${ASSIMP_LIBRARIES}
                                                      GLEW::GLEW
                                                      glfw
                                                      ${OpenCV_LIBS}


### PR DESCRIPTION
Package `assimp` with version `<= 3.2.0` has issues with the variable `ASSIMP_INCLUDE_DIRS` that contains a wrong non-existing path. Next versions solve this issue.

Also `-L${ASSIMP_LIBRARY_DIRS}` is not required anymore in `target_link_libraries`.
